### PR TITLE
update outline esp

### DIFF
--- a/src/main/java/keystrokesmod/mixins/impl/render/MixinRenderGlobal.java
+++ b/src/main/java/keystrokesmod/mixins/impl/render/MixinRenderGlobal.java
@@ -69,8 +69,8 @@ public class MixinRenderGlobal {
         if (entityIn == viewer && this.mc.gameSettings.thirdPersonView == 0 && !flag) {
             return false;
         }
-        else if (shouldRender() && !AntiBot.isBot(entityIn)) {
-            return entityIn != viewer || ModuleManager.playerESP.renderSelf.isToggled();
+        else if (shouldRender()) {
+            return (entityIn != viewer && !AntiBot.isBot(entityIn)) || (entityIn == viewer && ModuleManager.playerESP.renderSelf.isToggled());
         }
         else {
             if (this.mc.thePlayer.isSpectator() && this.mc.gameSettings.keyBindSpectatorOutlines.isKeyDown() && entityIn instanceof EntityPlayer) {

--- a/src/main/java/keystrokesmod/mixins/impl/render/MixinRenderGlobal.java
+++ b/src/main/java/keystrokesmod/mixins/impl/render/MixinRenderGlobal.java
@@ -1,0 +1,83 @@
+package keystrokesmod.mixins.impl.render;
+
+import keystrokesmod.module.ModuleManager;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.renderer.RenderGlobal;
+import net.minecraft.client.renderer.culling.ICamera;
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(RenderGlobal.class)
+public class MixinRenderGlobal {
+    @Shadow
+    @Final
+    private Minecraft mc;
+
+    @Unique
+    private boolean shouldRender() {
+        return ModuleManager.playerESP != null && ModuleManager.playerESP.isEnabled() && ModuleManager.playerESP.outline.isToggled();
+    }
+
+    @Redirect(method = "isRenderEntityOutlines", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/entity/EntityPlayerSP;isSpectator()Z"))
+    private boolean forceIsSpectator(EntityPlayerSP instance) {
+        if (shouldRender()) {
+            return true;
+        }
+        else {
+            return instance.isSpectator();
+        }
+    }
+
+    @Redirect(method = "isRenderEntityOutlines", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/settings/KeyBinding;isKeyDown()Z"))
+    private boolean forceIsKeyDown(KeyBinding instance) {
+        if (shouldRender()) {
+            return true;
+        }
+        else {
+            return instance.isKeyDown();
+        }
+    }
+
+    @Redirect(method = "renderEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;shouldRenderInPass(I)Z", ordinal = 1))
+    private boolean forceShouldRenderInPass(Entity instance, int pass, Entity renderViewEntity, ICamera camera, float partialTicks) {
+        if (pass == 1) {
+            return true;
+        }
+        else {
+            return instance.shouldRenderInPass(pass);
+        }
+    }
+
+    @Redirect(method = "renderEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;isInRangeToRender3d(DDD)Z", ordinal = 1))
+    private boolean forceIsInRangeToRender(Entity instance, double x, double y, double z, Entity renderViewEntity, ICamera camera, float partialTicks) {
+        return instance.isInRangeToRender3d(x, y, z) && isOutlineActive(instance, renderViewEntity, camera);
+    }
+
+    @Unique
+    private boolean isOutlineActive(Entity entityIn, Entity viewer, ICamera camera) {
+        boolean flag = viewer instanceof EntityLivingBase && ((EntityLivingBase) viewer).isPlayerSleeping();
+        if (entityIn == viewer && this.mc.gameSettings.thirdPersonView == 0 && !flag) {
+            return false;
+        }
+        else if (shouldRender()) {
+            return entityIn != viewer || ModuleManager.playerESP.renderSelf.isToggled();
+        }
+        else {
+            if (this.mc.thePlayer.isSpectator() && this.mc.gameSettings.keyBindSpectatorOutlines.isKeyDown() && entityIn instanceof EntityPlayer) {
+                return entityIn.ignoreFrustumCheck || camera.isBoundingBoxInFrustum(entityIn.getEntityBoundingBox()) || entityIn.isRiding();
+            }
+            else {
+                return false;
+            }
+        }
+    }
+}

--- a/src/main/java/keystrokesmod/mixins/impl/render/MixinRenderGlobal.java
+++ b/src/main/java/keystrokesmod/mixins/impl/render/MixinRenderGlobal.java
@@ -1,6 +1,7 @@
 package keystrokesmod.mixins.impl.render;
 
 import keystrokesmod.module.ModuleManager;
+import keystrokesmod.module.impl.world.AntiBot;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.renderer.RenderGlobal;
@@ -68,7 +69,7 @@ public class MixinRenderGlobal {
         if (entityIn == viewer && this.mc.gameSettings.thirdPersonView == 0 && !flag) {
             return false;
         }
-        else if (shouldRender()) {
+        else if (shouldRender() && !AntiBot.isBot(entityIn)) {
             return entityIn != viewer || ModuleManager.playerESP.renderSelf.isToggled();
         }
         else {

--- a/src/main/java/keystrokesmod/mixins/impl/render/MixinRendererLivingEntity.java
+++ b/src/main/java/keystrokesmod/mixins/impl/render/MixinRendererLivingEntity.java
@@ -1,6 +1,7 @@
 package keystrokesmod.mixins.impl.render;
 
 import keystrokesmod.module.ModuleManager;
+import keystrokesmod.module.impl.world.AntiBot;
 import keystrokesmod.utility.Utils;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.model.ModelBase;
@@ -33,7 +34,7 @@ public abstract class MixinRendererLivingEntity<T extends EntityLivingBase> exte
     @Redirect(method = "doRender(Lnet/minecraft/entity/EntityLivingBase;DDDFF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/RendererLivingEntity;setScoreTeamColor(Lnet/minecraft/entity/EntityLivingBase;)Z"))
     private boolean setOutlineColor(RendererLivingEntity instance, T entityLivingBaseIn) {
         int i = 16777215;
-        boolean drawOutline = ModuleManager.playerESP != null && ModuleManager.playerESP.isEnabled() && ModuleManager.playerESP.outline.isToggled();
+        boolean drawOutline = ModuleManager.playerESP != null && ModuleManager.playerESP.isEnabled() && ModuleManager.playerESP.outline.isToggled() && !AntiBot.isBot(entityLivingBaseIn);
 
         if (!drawOutline || ModuleManager.playerESP.teamColor.isToggled())
         {

--- a/src/main/java/keystrokesmod/mixins/impl/render/MixinRendererLivingEntity.java
+++ b/src/main/java/keystrokesmod/mixins/impl/render/MixinRendererLivingEntity.java
@@ -31,10 +31,11 @@ public abstract class MixinRendererLivingEntity<T extends EntityLivingBase> exte
     }
 
     @Redirect(method = "doRender(Lnet/minecraft/entity/EntityLivingBase;DDDFF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/RendererLivingEntity;setScoreTeamColor(Lnet/minecraft/entity/EntityLivingBase;)Z"))
-    private boolean setScoreTeamColor(RendererLivingEntity instance, T entityLivingBaseIn) {
+    private boolean setOutlineColor(RendererLivingEntity instance, T entityLivingBaseIn) {
         int i = 16777215;
+        boolean drawOutline = ModuleManager.playerESP != null && ModuleManager.playerESP.isEnabled() && ModuleManager.playerESP.outline.isToggled();
 
-        if (ModuleManager.playerESP.teamColor.isToggled())
+        if (!drawOutline || ModuleManager.playerESP.teamColor.isToggled())
         {
             if (entityLivingBaseIn instanceof EntityPlayer)
             {
@@ -58,7 +59,7 @@ public abstract class MixinRendererLivingEntity<T extends EntityLivingBase> exte
             i = (new Color((int) ModuleManager.playerESP.red.getInput(), (int) ModuleManager.playerESP.green.getInput(), (int) ModuleManager.playerESP.blue.getInput())).getRGB();
         }
 
-        if (ModuleManager.playerESP.redOnDamage.isToggled() && entityLivingBaseIn.hurtTime != 0) {
+        if (drawOutline && ModuleManager.playerESP.redOnDamage.isToggled() && entityLivingBaseIn.hurtTime != 0) {
             i = Color.RED.getRGB();
         }
 

--- a/src/main/java/keystrokesmod/mixins/impl/render/MixinRendererLivingEntity.java
+++ b/src/main/java/keystrokesmod/mixins/impl/render/MixinRendererLivingEntity.java
@@ -3,8 +3,8 @@ package keystrokesmod.mixins.impl.render;
 import keystrokesmod.module.ModuleManager;
 import keystrokesmod.module.impl.world.AntiBot;
 import keystrokesmod.utility.Utils;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.entity.Render;
@@ -14,7 +14,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.scoreboard.ScorePlayerTeam;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
@@ -22,19 +21,14 @@ import java.awt.*;
 
 @Mixin(RendererLivingEntity.class)
 public abstract class MixinRendererLivingEntity<T extends EntityLivingBase> extends Render<T> {
-    @Shadow
-    protected ModelBase mainModel;
-
-    protected MixinRendererLivingEntity(RenderManager p_i46156_1_, ModelBase p_i46156_2_, float p_i46156_3_) {
-        super(p_i46156_1_);
-        this.mainModel = p_i46156_2_;
-        this.shadowSize = p_i46156_3_;
+    protected MixinRendererLivingEntity(RenderManager renderManager) {
+        super(renderManager);
     }
 
     @Redirect(method = "doRender(Lnet/minecraft/entity/EntityLivingBase;DDDFF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/RendererLivingEntity;setScoreTeamColor(Lnet/minecraft/entity/EntityLivingBase;)Z"))
     private boolean setOutlineColor(RendererLivingEntity instance, T entityLivingBaseIn) {
         int i = 16777215;
-        boolean drawOutline = ModuleManager.playerESP != null && ModuleManager.playerESP.isEnabled() && ModuleManager.playerESP.outline.isToggled() && !AntiBot.isBot(entityLivingBaseIn);
+        boolean drawOutline = ModuleManager.playerESP != null && ModuleManager.playerESP.isEnabled() && ModuleManager.playerESP.outline.isToggled() && ((entityLivingBaseIn != Minecraft.getMinecraft().thePlayer && !AntiBot.isBot(entityLivingBaseIn)) || (entityLivingBaseIn == Minecraft.getMinecraft().thePlayer && ModuleManager.playerESP.renderSelf.isToggled()));
 
         if (!drawOutline || ModuleManager.playerESP.teamColor.isToggled())
         {

--- a/src/main/java/keystrokesmod/mixins/impl/render/MixinRendererLivingEntity.java
+++ b/src/main/java/keystrokesmod/mixins/impl/render/MixinRendererLivingEntity.java
@@ -1,24 +1,21 @@
 package keystrokesmod.mixins.impl.render;
 
 import keystrokesmod.module.ModuleManager;
-import keystrokesmod.module.impl.world.AntiBot;
 import keystrokesmod.utility.Utils;
-import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.entity.RendererLivingEntity;
-import net.minecraft.client.shader.Framebuffer;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import org.lwjgl.opengl.EXTFramebufferObject;
-import org.lwjgl.opengl.EXTPackedDepthStencil;
-import org.lwjgl.opengl.GL11;
+import net.minecraft.scoreboard.ScorePlayerTeam;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.awt.*;
 
@@ -33,147 +30,48 @@ public abstract class MixinRendererLivingEntity<T extends EntityLivingBase> exte
         this.shadowSize = p_i46156_3_;
     }
 
-    @Overwrite
-    protected void renderModel(T p_renderModel_1_, float p_renderModel_2_, float p_renderModel_3_, float p_renderModel_4_, float p_renderModel_5_, float p_renderModel_6_, float p_renderModel_7_) {
-        boolean flag = !p_renderModel_1_.isInvisible();
-        boolean flag1 = !flag && !p_renderModel_1_.isInvisibleToPlayer(Minecraft.getMinecraft().thePlayer);
-        boolean drawOutline = ModuleManager.playerESP != null && ModuleManager.playerESP.isEnabled() && ModuleManager.playerESP.outline.isToggled();
-        if (flag || flag1) {
-            if (!this.bindEntityTexture(p_renderModel_1_)) {
-                return;
-            }
+    @Redirect(method = "doRender(Lnet/minecraft/entity/EntityLivingBase;DDDFF)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/RendererLivingEntity;setScoreTeamColor(Lnet/minecraft/entity/EntityLivingBase;)Z"))
+    private boolean setScoreTeamColor(RendererLivingEntity instance, T entityLivingBaseIn) {
+        int i = 16777215;
 
-            if (flag1) {
-                GlStateManager.pushMatrix();
-                GlStateManager.color(1.0F, 1.0F, 1.0F, 0.15F);
-                GlStateManager.depthMask(false);
-                GlStateManager.enableBlend();
-                GlStateManager.blendFunc(770, 771);
-                GlStateManager.alphaFunc(516, 0.003921569F);
-            }
+        if (ModuleManager.playerESP.teamColor.isToggled())
+        {
+            if (entityLivingBaseIn instanceof EntityPlayer)
+            {
+                ScorePlayerTeam scoreplayerteam = (ScorePlayerTeam)entityLivingBaseIn.getTeam();
 
-            if (drawOutline && p_renderModel_1_ instanceof EntityPlayer) {
-                if (((p_renderModel_1_ != Minecraft.getMinecraft().thePlayer && !AntiBot.isBot(p_renderModel_1_)) || (ModuleManager.playerESP.renderSelf.isToggled() && p_renderModel_1_ == Minecraft.getMinecraft().thePlayer))) {
-                    GlStateManager.pushMatrix();
-                    int color;
-                    if (ModuleManager.playerESP.teamColor.isToggled()) {
-                        color = ModuleManager.playerESP.getColorFromTags(p_renderModel_1_.getDisplayName().getFormattedText());
+                if (scoreplayerteam != null)
+                {
+                    String s = FontRenderer.getFormatFromString(scoreplayerteam.getColorPrefix());
+
+                    if (s.length() >= 2)
+                    {
+                        i = this.getFontRendererFromRenderManager().getColorCode(s.charAt(1));
                     }
-                    else if (ModuleManager.playerESP.rainbow.isToggled()) {
-                        color =  Utils.getChroma(2L, 0L);
-                    }
-                    else {
-                        color = (new Color((int) ModuleManager.playerESP.red.getInput(), (int) ModuleManager.playerESP.green.getInput(), (int) ModuleManager.playerESP.blue.getInput())).getRGB();
-                    }
-                    if (ModuleManager.playerESP.redOnDamage.isToggled() && p_renderModel_1_.hurtTime != 0) {
-                        color = Color.RED.getRGB();
-                    }
-                    glColor(color);
-                    this.mainModel.render(p_renderModel_1_, p_renderModel_2_, p_renderModel_3_, p_renderModel_4_, p_renderModel_5_, p_renderModel_6_, p_renderModel_7_);
-                    renderOne();
-                    glColor(color);
-                    this.mainModel.render(p_renderModel_1_, p_renderModel_2_, p_renderModel_3_, p_renderModel_4_, p_renderModel_5_, p_renderModel_6_, p_renderModel_7_);
-                    renderTwo();
-                    glColor(color);
-                    this.mainModel.render(p_renderModel_1_, p_renderModel_2_, p_renderModel_3_, p_renderModel_4_, p_renderModel_5_, p_renderModel_6_, p_renderModel_7_);
-                    renderThree();
-                    renderFour();
-                    glColor(color);
-                    this.mainModel.render(p_renderModel_1_, p_renderModel_2_, p_renderModel_3_, p_renderModel_4_, p_renderModel_5_, p_renderModel_6_, p_renderModel_7_);
-                    renderFive();
-                    GL11.glColor4f(1, 1, 1, 1);
-                    GlStateManager.popMatrix();
                 }
             }
-
-            this.mainModel.render(p_renderModel_1_, p_renderModel_2_, p_renderModel_3_, p_renderModel_4_, p_renderModel_5_, p_renderModel_6_, p_renderModel_7_);
-            if (flag1) {
-                GlStateManager.disableBlend();
-                GlStateManager.alphaFunc(516, 0.1F);
-                GlStateManager.popMatrix();
-                GlStateManager.depthMask(true);
-            }
+        }
+        else if (ModuleManager.playerESP.rainbow.isToggled()) {
+            i = Utils.getChroma(2L, 0L);
+        }
+        else {
+            i = (new Color((int) ModuleManager.playerESP.red.getInput(), (int) ModuleManager.playerESP.green.getInput(), (int) ModuleManager.playerESP.blue.getInput())).getRGB();
         }
 
-    }
-
-    private void renderOne() {
-        checkSetupFBO();
-        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
-        GL11.glDisable(GL11.GL_ALPHA_TEST);
-        GL11.glDisable(GL11.GL_TEXTURE_2D);
-        GL11.glDisable(GL11.GL_LIGHTING);
-        GL11.glEnable(GL11.GL_BLEND);
-        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-        GL11.glLineWidth(7); // width
-        GL11.glEnable(GL11.GL_LINE_SMOOTH);
-        GL11.glEnable(GL11.GL_STENCIL_TEST);
-        GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
-        GL11.glClearStencil(0xF);
-        GL11.glStencilFunc(GL11.GL_NEVER, 1, 0xF);
-        GL11.glStencilOp(GL11.GL_REPLACE, GL11.GL_REPLACE, GL11.GL_REPLACE);
-        GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_LINE);
-    }
-
-    private void renderTwo() {
-        GL11.glStencilFunc(GL11.GL_NEVER, 0, 0xF);
-        GL11.glStencilOp(GL11.GL_REPLACE, GL11.GL_REPLACE, GL11.GL_REPLACE);
-        GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_FILL);
-    }
-
-    private void renderThree() {
-        GL11.glStencilFunc(GL11.GL_EQUAL, 1, 0xF);
-        GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_KEEP);
-        GL11.glPolygonMode(GL11.GL_FRONT_AND_BACK, GL11.GL_LINE);
-    }
-
-    private void renderFour() {
-        setColor(new Color(255, 255, 255));
-        GL11.glDepthMask(false);
-        GL11.glDisable(GL11.GL_DEPTH_TEST);
-        GL11.glEnable(GL11.GL_POLYGON_OFFSET_LINE);
-        GL11.glPolygonOffset(1.0F, -2000000F);
-        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240.0F, 240.0F);
-    }
-
-    private void renderFive() {
-        GL11.glPolygonOffset(1.0F, 2000000F);
-        GL11.glDisable(GL11.GL_POLYGON_OFFSET_LINE);
-        GL11.glEnable(GL11.GL_DEPTH_TEST);
-        GL11.glDepthMask(true);
-        GL11.glDisable(GL11.GL_STENCIL_TEST);
-        GL11.glDisable(GL11.GL_LINE_SMOOTH);
-        GL11.glHint(GL11.GL_LINE_SMOOTH_HINT, GL11.GL_DONT_CARE);
-        GL11.glEnable(GL11.GL_BLEND);
-        GL11.glEnable(GL11.GL_LIGHTING);
-        GL11.glEnable(GL11.GL_TEXTURE_2D);
-        GL11.glEnable(GL11.GL_ALPHA_TEST);
-        GL11.glPopAttrib();
-    }
-
-    private void setColor(Color c) {
-        GL11.glColor4d(c.getRed() / 255f, c.getGreen() / 255f, c.getBlue() / 255f, c.getAlpha() / 255f);
-    }
-
-    private void checkSetupFBO() {
-        Framebuffer fbo = Minecraft.getMinecraft().getFramebuffer();
-        if (fbo != null) {
-            if (fbo.depthBuffer > -1) {
-                setupFBO(fbo);
-                fbo.depthBuffer = -1;
-            }
+        if (ModuleManager.playerESP.redOnDamage.isToggled() && entityLivingBaseIn.hurtTime != 0) {
+            i = Color.RED.getRGB();
         }
-    }
-    private void setupFBO(Framebuffer fbo) {
-        EXTFramebufferObject.glDeleteRenderbuffersEXT(fbo.depthBuffer);
-        int stencil_depth_buffer_ID = EXTFramebufferObject.glGenRenderbuffersEXT();
-        EXTFramebufferObject.glBindRenderbufferEXT(EXTFramebufferObject.GL_RENDERBUFFER_EXT, stencil_depth_buffer_ID);
-        EXTFramebufferObject.glRenderbufferStorageEXT(EXTFramebufferObject.GL_RENDERBUFFER_EXT, EXTPackedDepthStencil.GL_DEPTH_STENCIL_EXT, Minecraft.getMinecraft().displayWidth, Minecraft.getMinecraft().displayHeight);
-        EXTFramebufferObject.glFramebufferRenderbufferEXT(EXTFramebufferObject.GL_FRAMEBUFFER_EXT, EXTFramebufferObject.GL_STENCIL_ATTACHMENT_EXT, EXTFramebufferObject.GL_RENDERBUFFER_EXT, stencil_depth_buffer_ID);
-        EXTFramebufferObject.glFramebufferRenderbufferEXT(EXTFramebufferObject.GL_FRAMEBUFFER_EXT, EXTFramebufferObject.GL_DEPTH_ATTACHMENT_EXT, EXTFramebufferObject.GL_RENDERBUFFER_EXT, stencil_depth_buffer_ID);
-    }
 
-    private void glColor(int color) {
-        GL11.glColor4ub((byte) (color >> 16 & 0xFF), (byte) (color >> 8 & 0xFF), (byte) (color & 0xFF), (byte) (color >> 24 & 0xFF));
+        float f1 = (float)(i >> 16 & 255) / 255.0F;
+        float f2 = (float)(i >> 8 & 255) / 255.0F;
+        float f = (float)(i & 255) / 255.0F;
+        GlStateManager.disableLighting();
+        GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
+        GlStateManager.color(f1, f2, f, 1.0F);
+        GlStateManager.disableTexture2D();
+        GlStateManager.setActiveTexture(OpenGlHelper.lightmapTexUnit);
+        GlStateManager.disableTexture2D();
+        GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
+        return true;
     }
 }

--- a/src/main/resources/mixins.raven.json
+++ b/src/main/resources/mixins.raven.json
@@ -17,6 +17,7 @@
     "network.MixinModList",
     "client.MixinMovementInputFromOptions",
     "client.MixinMinecraft",
-    "render.MixinItemRenderer"
+    "render.MixinItemRenderer",
+    "render.MixinRenderGlobal"
   ]
 }


### PR DESCRIPTION
uses minecraft's built in spectator outline/glow instead of drawing the outline manually via renderModel
this also brings parity to raven b4's outline esp

could this have been done better? probably, but it works and is much better than the old implementation so idrc

<details>
  <summary>preview</summary>

  ![preview](https://github.com/user-attachments/assets/ed3f997f-d5dd-4137-b48a-a85eb9115bed)
</details>
