### PR TITLE
InteractTicks being reset before it can reach case 3

### DIFF
--- a/src/main/java/keystrokesmod/module/impl/combat/KillAura.java
+++ b/src/main/java/keystrokesmod/module/impl/combat/KillAura.java
@@ -705,16 +705,13 @@ public class KillAura extends Module {
         }
         switch ((int) autoBlockMode.getInput()) {
             case 4: // interact a
-                if (interactTicks >= 3) {
-                    interactTicks = 0;
-                }
                 interactTicks++;
                 if (firstCycle) {
                     switch (interactTicks) {
                         case 1:
                             blinking.set(true);
                             int bestSwapSlot = getBestSwapSlot();
-                            mc.thePlayer.sendQueue.addToSendQueue(new C09PacketHeldItemChange( bestSwapSlot));
+                            mc.thePlayer.sendQueue.addToSendQueue(new C09PacketHeldItemChange(bestSwapSlot));
                             Raven.packetsHandler.playerSlot.set(bestSwapSlot);
                             swapped = true;
                             lag = false;
@@ -733,7 +730,9 @@ public class KillAura extends Module {
                             break;
                     }
                 }
-                else {
+                if (interactTicks >= 3) {
+                    interactTicks = 0;
+                } else {
                     switch (interactTicks) {
                         case 1:
                             break;
@@ -741,7 +740,7 @@ public class KillAura extends Module {
                             lag = false;
                             int bestSwapSlot = getBestSwapSlot();
                             blinking.set(true);
-                            mc.thePlayer.sendQueue.addToSendQueue(new C09PacketHeldItemChange( bestSwapSlot));
+                            mc.thePlayer.sendQueue.addToSendQueue(new C09PacketHeldItemChange(bestSwapSlot));
                             Raven.packetsHandler.playerSlot.set(bestSwapSlot);
                             swapped = true;
                             break;
@@ -759,9 +758,6 @@ public class KillAura extends Module {
                 }
                 break;
             case 5: // interact b
-                if (interactTicks >= 3) {
-                    interactTicks = 0;
-                }
                 interactTicks++;
                 switch (interactTicks) {
                     case 1:
@@ -770,7 +766,7 @@ public class KillAura extends Module {
                         lag = false;
                         int bestSwapSlot = getBestSwapSlot();
                         blinking.set(true);
-                        mc.thePlayer.sendQueue.addToSendQueue(new C09PacketHeldItemChange( bestSwapSlot));
+                        mc.thePlayer.sendQueue.addToSendQueue(new C09PacketHeldItemChange(bestSwapSlot));
                         Raven.packetsHandler.playerSlot.set(bestSwapSlot);
                         swapped = true;
                         break;
@@ -785,11 +781,11 @@ public class KillAura extends Module {
                         lag = true;
                         break;
                 }
-                break;
-            case 6: // interact c
                 if (interactTicks >= 3) {
                     interactTicks = 0;
                 }
+                break;
+            case 6: // interact c
                 interactTicks++;
                 switch (interactTicks) {
                     case 2:
@@ -811,11 +807,11 @@ public class KillAura extends Module {
                         lag = true;
                         break;
                 }
-                break;
-            case 7: // interact d
                 if (interactTicks >= 3) {
                     interactTicks = 0;
                 }
+                break;
+            case 7: // interact d
                 interactTicks++;
                 switch (interactTicks) {
                     case 1:
@@ -830,7 +826,11 @@ public class KillAura extends Module {
                         lag = true;
                         break;
                 }
+                if (interactTicks >= 3) {
+                    interactTicks = 0;
+                }
                 break;
+
         }
     }
 


### PR DESCRIPTION
Reported by Stephen
i moved the logic to be correct and now im lasting using auto blocks potentially being the causing reason of quick bans

Old code caused case 3 not to be reached as interactTicks were reset too early